### PR TITLE
Pass back the response even when something is going wrong.

### DIFF
--- a/src/frisbee.js
+++ b/src/frisbee.js
@@ -134,7 +134,7 @@ export default class Frisbee {
         )
         .catch(err => {
           if (!response || !response.statusText) {
-            if (callback) return callback(err);
+            if (callback) return callback(err, response || null);
             throw err;
           }
 


### PR DESCRIPTION
Currently if the response does not have statusText when it is erroring out it does not send the response to the callback which is troublesome since the failure response might have helpful information. This quick little change will attempt to pass back the response (or null if its missing somehow) so that the caller can get at any additional information they may need.