### PR TITLE
Make body.json() not get called if body.text() and allow for the Accept Header

### DIFF
--- a/src/frisbee.js
+++ b/src/frisbee.js
@@ -114,15 +114,19 @@ export default class Frisbee {
 
           }
 
-          if (opts.headers['Content-Type'] !== 'application/json')
+          if (opts.headers['Content-Type'] !== 'application/json' && opts.headers['Accept'] !== 'application/json') {
             body = res.text();
-
-          try {
-            body = res.json();
-          } catch (err) {
-            const message = `Failed to parse JSON body: ${err.message}`;
-            if (callback) { return callback(message); }
-            throw new Error(message);
+          }
+          else {
+            try {
+              body = res.json();
+            } catch (err) {
+              var message = 'Failed to parse JSON body: ' + err.message;
+              if (callback) {
+                return callback(message);
+              }
+              throw new Error(message);
+            }
           }
 
           return body;


### PR DESCRIPTION
If you specified anything that was not application/json you would get an error since the code was trying to run both res.text() and res.json(). In addition I have added limited support for the 'Accept' header in the event that you need to send data in a form that isn't JSON but expect JSON back.

http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html - Accept Header Ref