### PR TITLE
switch to using fetch ponyfill

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,9 +57,6 @@
         # optional (to support older browsers):
         npm install --save es6-promise
 
-        # required (to add global `fetch` method):
-        npm install --save isomorphic-fetch
-
         # required (this package):
         npm install --save frisbee
         ```
@@ -68,9 +65,6 @@
         ```bash
         # optional (to support older browsers):
         bower install --save es6-promise
-
-        # required (to add global `fetch` method):
-        bower install --save isomorphic-fetch
 
         # required (this package):
         bower install --save frisbee
@@ -82,10 +76,6 @@
     // add optional support for older browsers
     import es6promise from 'es6-promise';
     es6promise.polyfill();
-
-    // add required support for global `fetch` method
-    // *this must always come before `frisbee` is imported*
-    import 'isomorphic-fetch';
 
     // require the module
     import Frisbee from 'frisbee';

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -3,10 +3,6 @@
 import es6promise from 'es6-promise';
 es6promise.polyfill();
 
-// add required support for global `fetch` method
-// *this must always come before `frisbee` is imported*
-import 'isomorphic-fetch';
-
 // require the module
 import Frisbee from 'frisbee';
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "frisbee",
-  "description":
-    "Stripe-inspired API wrapper around WHATWG's fetch() method for making simple HTTP requests (alternative to superagent, request, axios)",
+  "description": "Stripe-inspired API wrapper around WHATWG's fetch() method for making simple HTTP requests (alternative to superagent, request, axios)",
   "version": "1.6.0",
   "author": "Nick Baugh <niftylettuce@gmail.com>",
   "bugs": {
@@ -12,6 +11,7 @@
     "babel-runtime": "^6.9.2",
     "buffer": "^4.6.0",
     "caseless": "^0.11.0",
+    "fetch-ponyfill": "^4.1.0",
     "qs": "^6.2.0"
   },
   "devDependencies": {
@@ -82,20 +82,14 @@
     "url": "https://github.com/joinspontaneous/frisbee"
   },
   "scripts": {
-    "analyze-coverage":
-      "NODE_ENV=test node_modules/.bin/babel-node node_modules/.bin/isparta cover node_modules/.bin/_mocha",
-    "browserify":
-      "node_modules/.bin/browserify -t babelify test/unit/browser.js > test/unit/browser.bundled.js",
+    "analyze-coverage": "NODE_ENV=test node_modules/.bin/babel-node node_modules/.bin/isparta cover node_modules/.bin/_mocha",
+    "browserify": "node_modules/.bin/browserify -t babelify test/unit/browser.js > test/unit/browser.bundled.js",
     "build": "node_modules/.bin/babel src --modules common --out-dir lib",
-    "check-coverage":
-      "node_modules/.bin/babel-node node_modules/.bin/istanbul check-coverage",
-    "coverage":
-      "npm run lint && npm run build && npm run analyze-coverage && npm run check-coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage/",
+    "check-coverage": "node_modules/.bin/babel-node node_modules/.bin/istanbul check-coverage",
+    "coverage": "npm run lint && npm run build && npm run analyze-coverage && npm run check-coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage/",
     "lint": "node_modules/.bin/eslint .",
     "prepublish": "npm run build",
-    "test":
-      "npm run lint && npm run browserify && NODE_ENV=test _mocha --compilers js:babel-core/register",
-    "watch":
-      "node_modules/.bin/babel src --watch --modules common --out-dir lib --source-maps"
+    "test": "npm run lint && npm run browserify && NODE_ENV=test _mocha --compilers js:babel-core/register",
+    "watch": "node_modules/.bin/babel src --watch --modules common --out-dir lib --source-maps"
   }
 }

--- a/src/frisbee.js
+++ b/src/frisbee.js
@@ -11,19 +11,10 @@
 import caseless from 'caseless';
 import qs from 'qs';
 import { Buffer } from 'buffer';
+import fetchPonyfill from 'fetch-ponyfill';
 import Interceptor from './interceptor';
 
-const fetch = typeof window === 'object' ? window.fetch : global.fetch;
-
-if (!fetch)
-  throw new Error(
-    'A global `fetch` method is required as either `window.fetch` '
-    + 'for browsers or `global.fetch` for node runtime environments. '
-    + 'Please add `require(\'isomorphic-fetch\')` before importing `frisbee`. '
-    + 'You may optionally `require(\'es6-promise\').polyfill()` before you '
-    + 'require `isomorphic-fetch` if you want to support older browsers.'
-    + '\n\nFor more info: https://github.com/niftylettuce/frisbee#usage'
-  );
+const { fetch } = fetchPonyfill({ Promise });
 
 const methods = [
   'get',

--- a/test/unit/browser.js
+++ b/test/unit/browser.js
@@ -1,5 +1,4 @@
 import es6promise from 'es6-promise';
 es6promise.polyfill();
-import 'isomorphic-fetch';
 import Frisbee from '../../lib/frisbee';
 window.Frisbee = Frisbee;

--- a/test/unit/browser.test.js
+++ b/test/unit/browser.test.js
@@ -31,10 +31,6 @@ describe('browser', () => {
     server.close();
   });
 
-  it('should have `fetch` defined', () => {
-    expect(window.fetch).to.exist();
-  });
-
   // <https://github.com/niftylettuce/node-react-native-fetch-api>
   /*
   it('should throw an error if we fail to pass baseURI', () => {

--- a/test/unit/node.test.js
+++ b/test/unit/node.test.js
@@ -1,5 +1,4 @@
 
-import 'isomorphic-fetch';
 import Frisbee from '../../lib/frisbee';
 const app = require('./app');
 
@@ -22,10 +21,6 @@ describe('node runtime', () => {
   });
 
   after(done => server.close(done));
-
-  it('should have `fetch` defined', () => {
-    expect(fetch).to.exist();
-  });
 
   // <https://github.com/niftylettuce/node-react-native-fetch-api>
   it('should throw an error if we fail to pass baseURI', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,6 +1889,12 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fetch-ponyfill@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz#ae3ce5f732c645eab87e4ae8793414709b239893"
+  dependencies:
+    node-fetch "~1.7.1"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -2910,6 +2916,13 @@ nise@^1.0.1:
 node-fetch@^1.0.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.2.tgz#c54e9aac57e432875233525f3c891c4159ffefd7"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
+node-fetch@~1.7.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"


### PR DESCRIPTION
This removes the need for `isomorphic-fetch` as a side effect `fetch` won't be a global anymore.

All tests are passing. I did have to remove 2 tests though as they were directly related to checking if fetch was a global.