### PR TITLE
add better URL validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "buffer": "^4.6.0",
     "caseless": "^0.11.0",
     "fetch-ponyfill": "^4.1.0",
-    "qs": "^6.2.0"
+    "qs": "^6.2.0",
+    "url-join": "^2.0.2"
   },
   "devDependencies": {
     "@earnest/eslint-config-es7": "^2.1.1",

--- a/src/frisbee.js
+++ b/src/frisbee.js
@@ -12,6 +12,7 @@ import caseless from 'caseless';
 import qs from 'qs';
 import { Buffer } from 'buffer';
 import fetchPonyfill from 'fetch-ponyfill';
+import urlJoin from 'url-join';
 import Interceptor from './interceptor';
 
 const { fetch } = fetchPonyfill({ Promise });
@@ -180,8 +181,8 @@ export default class Frisbee {
       return new Promise(async (resolve, reject) => {
 
         try {
-
-          const originalRes = await fetch(this.opts.baseURI + path, opts);
+          const fullUri = urlJoin(this.opts.baseURI, path);
+          const originalRes = await fetch(fullUri, opts);
           const res = createFrisbeeResponse(originalRes);
           const contentType = res.headers.get('Content-Type');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3944,6 +3944,10 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
+url-join@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.2.tgz#c072756967ad24b8b59e5741551caac78f50b8b7"
+
 url@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
This protects against dropping the path in baseURI. Before this patch baseURI would lose it's path and only retain everything before the first slash. This also protects against multiple slashes.

For example `http://localhost:8081/redappples/` was turning into `http://localhost:8081/` yet I needed the base path and was expecting this. For people that are expecting the old behaviour this may be an issue though so we might have to add a test and do a major bump.