### PR TITLE
add node v9 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "source-map-support": "^0.4.0"
   },
   "engines": {
-    "node": "6.x||7.x||8.x"
+    "node": "6.x||7.x||8.x||9.x"
   },
   "homepage": "https://github.com/joinspontaneous/frisbee",
   "keywords": [


### PR DESCRIPTION
All tests pass without any issues on `v9.2.0`.