### PR TITLE
fix falsy header value cause Error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ class Frisbee {
           opts.headers[key] === null ||
           opts.headers[key] === ''
         )
-          throw new Error('`options` must be an object');
+          delete opts.headers[key];
       });
 
       const c = caseless(opts.headers);

--- a/test/node.test.js
+++ b/test/node.test.js
@@ -94,6 +94,17 @@ test(
   }
 );
 
+test(
+  oneLine`should not throw an error
+  if headers with value ""|null|undefined`,
+  async t => {
+    const api = new Frisbee(options);
+    await t.notThrows(api.get('', { headers: { empty: '' } }));
+    await t.notThrows(api.get('', { headers: { null: null } }));
+    await t.notThrows(api.get('', { headers: { undefine: undefined } }));
+  }
+);
+
 standardMethods.forEach(method => {
   const methodName = method === 'del' ? 'DELETE' : method.toUpperCase();
 


### PR DESCRIPTION
when options.headers has falsy values, say `'', null, undefined`
it will cause an TypeError '`options` must be an object'

in old commit 06820478b468c74928cf89c679df8290195cff17
falsy values is only be remove when call fetch api.
https://github.com/niftylettuce/frisbee/blame/7b4b9e2b120e29d7484e677c8692cd55e2e9da21/src/frisbee.js#L155