### PR TITLE
Housekeeping - get build/tests running

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,7 +9,6 @@
   "plugins": [
     [ "@babel/transform-runtime", {
       "helpers": false,
-      "polyfill": false,
       "regenerator": true
     }],
     "@babel/plugin-proposal-object-rest-spread"

--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,8 @@
   "presets": [
     ["@babel/env", {
       "targets": {
-        "node": "6.4.0"
+        "node": "6.4.0",
+        "browsers": "last 2 versions"
       }
     }]
   ],

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,0 @@
-last 2 versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - '8'
   - '9'
   - '10'
+install:
+  - yarn install --ignore-engines
 script:
   npm run test-coverage
 after_success:

--- a/package.json
+++ b/package.json
@@ -160,7 +160,8 @@
       "capitalized-comments": "off",
       "camelcase": "off",
       "no-warning-comments": "off",
-      "prettier/prettier": "error"
+      "prettier/prettier": "error",
+      "ava/use-t-well": "off"
     },
     "space": true,
     "overrides": [

--- a/test/node.test.js
+++ b/test/node.test.js
@@ -57,7 +57,7 @@ test('should accept valid auth("user:pass") usage', t => {
 
 test('should allow chaining of `auth` and an HTTP method', async t => {
   const api = new Frisbee(options);
-  await t.notThrows(api.auth('foo', 'bar').get('/'));
+  await t.notThrows(() => api.auth('foo', 'bar').get('/'));
 });
 
 test('should allow removal of auth() header', t => {
@@ -68,21 +68,21 @@ test('should allow removal of auth() header', t => {
 
 test('should throw an error if we fail to pass a string `path`', async t => {
   const api = new Frisbee(options);
-  const error = await t.throws(api.get({}));
+  const error = await t.throws(() => api.get({}));
   t.is(error.message, '`path` must be a string');
 });
 
 test(`should throw an error if we fail to pass an object options`, async t => {
   const api = new Frisbee(options);
-  let error = await t.throws(api.get('', []));
+  let error = await t.throws(() => api.get('', []));
   t.is(error.message, '`options` must be an object');
-  error = await t.throws(api.get('', 1));
+  error = await t.throws(() => api.get('', 1));
   t.is(error.message, '`options` must be an object');
 });
 
 test('should throw an error if we pass a non object `options`', async t => {
   const api = new Frisbee(options);
-  const error = await t.throws(api.get('', false));
+  const error = await t.throws(() => api.get('', false));
   t.is(error.message, '`options` must be an object');
 });
 
@@ -90,7 +90,7 @@ test(
   oneLine`should automatically set options to an empty object if not set`,
   async t => {
     const api = new Frisbee(options);
-    await t.notThrows(api.get(''));
+    await t.notThrows(() => api.get(''));
   }
 );
 
@@ -99,9 +99,9 @@ test(
   if headers with value ""|null|undefined`,
   async t => {
     const api = new Frisbee(options);
-    await t.notThrows(api.get('', { headers: { empty: '' } }));
-    await t.notThrows(api.get('', { headers: { null: null } }));
-    await t.notThrows(api.get('', { headers: { undefine: undefined } }));
+    await t.notThrows(() => api.get('', { headers: { empty: '' } }));
+    await t.notThrows(() => api.get('', { headers: { null: null } }));
+    await t.notThrows(() => api.get('', { headers: { undefine: undefined } }));
   }
 );
 

--- a/test/node.test.js
+++ b/test/node.test.js
@@ -68,21 +68,21 @@ test('should allow removal of auth() header', t => {
 
 test('should throw an error if we fail to pass a string `path`', async t => {
   const api = new Frisbee(options);
-  const error = await t.throws(() => api.get({}));
+  const error = await t.throwsAsync(api.get({}));
   t.is(error.message, '`path` must be a string');
 });
 
 test(`should throw an error if we fail to pass an object options`, async t => {
   const api = new Frisbee(options);
-  let error = await t.throws(() => api.get('', []));
+  let error = await t.throwsAsync(() => api.get('', []));
   t.is(error.message, '`options` must be an object');
-  error = await t.throws(() => api.get('', 1));
+  error = await t.throwsAsync(() => api.get('', 1));
   t.is(error.message, '`options` must be an object');
 });
 
 test('should throw an error if we pass a non object `options`', async t => {
   const api = new Frisbee(options);
-  const error = await t.throws(() => api.get('', false));
+  const error = await t.throwsAsync(() => api.get('', false));
   t.is(error.message, '`options` must be an object');
 });
 


### PR DESCRIPTION
Been using frisbee for about a year now, and came across the bug-bounty repo today. Was getting started on the cross-fetch task, but ran into some deprecations/build issues.

There were a handful of separate issues, but for this PR I took the approach of **minimum change**.

1. Babel polyfill error - [can be seen on the latest travis build](https://travis-ci.org/niftylettuce/frisbee/jobs/477068401). Quick removal from `.babelrc`.
2. Babel environment problem: `.browserlistrc` was being ignored due to the `targets` config of `@babel/env` in the .babelrc file. The build contained `class`, `const` etc, while current release version of frisbee has only es5-level code. Tests were refusing to run.
  * Moved the browserlist config into .babelrc
3. Ava deprecations: the form of `throws` assertions have changed since 1.0-beta versions of ava.
  * I needed to disable an xo/eslint rule, due to the version of xo being locked down.
  * Could have just locked down ava to `1.0.0-beta.4`, but the yarn.lock already had a more recent version, so I figured a light test refactor was appropriate

---

Going to start the cross-fetch task from here, but would be happy to explore different approaches to anything.