### PR TITLE
Allow jwt to take null or undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,7 @@ class Frisbee {
   }
 
   jwt(token) {
-    if (token === null) delete this.headers.Authorization;
+    if (token === null || token === undefined) delete this.headers.Authorization;
     else if (typeof token === 'string')
       this.headers.Authorization = `Bearer ${token}`;
     else throw new TypeError('jwt token must be a string');


### PR DESCRIPTION
Minor change, but I've had to do this in my code which I'm not a big fan of:

`api.jwt(getTokens().accessToken || null)`