### PR TITLE
Use cross-fetch as a polyfill rather than a full source of implementa…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const caseless = require('caseless');
 const qs = require('qs');
-const fetch = require('cross-fetch');
+// eslint-disable-next-line import/no-unassigned-import
+require('cross-fetch/polyfill');
 const urlJoin = require('url-join');
 
 const Interceptor = require('./interceptor');


### PR DESCRIPTION
So I really want to use this library (you can probably tell by my PRs), but I'm unable to mock fetch in my (jest) unit tests because this library is using cross-fetch as a source of implementation (whatwg-fetch or node-fetch), rather than as a polyfill to only use one of those implementations when necessary. 

I'd argue it might be even better to remove cross-fetch completely and simply add it as a peer dependency (and dev dependency, for running the unit tests). This would be a breaking change, but I can't see how anybody can include this library in their code and write their own tests unless there is a mock provided for this library which seems like a lot of work, or fetch is provided through a polyfill rather than an implementation.