### PR TITLE
WIP: Retain trailing slash on GET requests with parameters (#88)

### DIFF
--- a/test/node.test.js
+++ b/test/node.test.js
@@ -152,6 +152,30 @@ standardMethods.forEach(method => {
   });
 });
 
+test.serial(
+  oneLine`should not strip trailing slash on GET requests with params`,
+  async t => {
+    // Since `express` does not distinguish `path/?param` from `path?param`,
+    // we instead spy on the URL passed to the `fetch()` call.
+    // `test.serial` is used to prevent global-stub errors.
+    sinon.stub(global, 'fetch');
+    try {
+      const api = new Frisbee(options);
+      try {
+        await api.get('/querystring/', { body: { param: 'foo' } });
+      } catch (err) {
+        // We broke `fetch`, so this is expected
+      }
+
+      const [url] = fetch.getCall(0).args;
+      const hasTrailingSlash = url.indexOf('querystring/?') !== -1;
+      t.true(hasTrailingSlash, 'Trailing slash is still present');
+    } finally {
+      fetch.restore();
+    }
+  }
+);
+
 test(
   oneLine`should stringify querystring parameters for GET and DELETE requests`,
   async t => {


### PR DESCRIPTION
Addressing issue #88 

WIP -- no changes implemented yet -- just a failing test.

At first, I tried to use the `express` test server for this test, but it didn't work out. Seems like express ignores these slashes. davidgovea@5d818f3d53e1fbe90e7d6000d978d219e36a3e4a

So, I went with a spy-on-fetch approach. Unfortunately, I had to use ava's `test.serial`, which I'd rather not have to do, but I didn't see another way to achieve this (I'm more used to jest's module-mocking).