### PR TITLE
Fix object spread on body

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ const Frisbee = require('frisbee');
 
     * **Tip**: You'll most likely want to set the `"Accept"` header to `"application/json"` and the `"Content-Type"` header to `"application/json"`
 
-  * `body` (Object) - an object containing default body payload to send with every request  (API method specific `params` options will override or extend properties defined here, but not deep merge)
+  * `body` (Object) - an object containing default body payload to send with every request (Provided body objects will shallow-merge with the defaults.)
 
   * `params` (Object) - an object containing default querystring parameters to send with every request (API method specific `params` options will override or extend properties defined here, but will not deep merge)
 

--- a/src/index.js
+++ b/src/index.js
@@ -286,8 +286,11 @@ class Frisbee {
         signal
       };
 
-      if (this.opts.body || options.body)
-        opts.body = { ...this.opts.body, ...options.body };
+      if (this.opts.body || options.body) {
+        opts.body = typeof options.body === 'object'
+          ? {...this.opts.body, ...options.body}
+          : (options.body ? options.body : this.opts.body);
+      }
 
       if (this.opts.params || options.params)
         opts.params = { ...this.opts.params, ...options.params };


### PR DESCRIPTION
Fixes #94 by enforcing a type check on the provided body; if it is an object, it's safe to do a spread with the default. Otherwise, it passes through as-is. Addresses the need to send strings, for instance.

Keep in mind I'm not normally a JavaScript developer and haven't been able to run automated tests locally, though I have tested this locally in so far as it fixes the problem described in the ticket.